### PR TITLE
Support some syntax sugar

### DIFF
--- a/core/deps/context.js
+++ b/core/deps/context.js
@@ -16,29 +16,6 @@ var Context = inherit(Deps, /** @lends Context.prototype */ {
      * @memberOf {Context}
      * @method
      *
-     * @param {String} name
-     *
-     * @returns {*}
-     * */
-    arg: function (name) {
-        var result = this.__base(name);
-
-        if ( _.isUndefined(result) || _.isNull(result) ) {
-            result = this.track.match[name];
-
-            if ( _.isUndefined(result) || _.isNull(result) ) {
-                result = this.track.url.query[name];
-            }
-        }
-
-        return result;
-    },
-
-    /**
-     * @public
-     * @memberOf {Context}
-     * @method
-     *
      * @param {String} renderer
      *
      * @returns {vow.Promise}
@@ -50,18 +27,16 @@ var Context = inherit(Deps, /** @lends Context.prototype */ {
     },
 
     /**
-     * @public
+     * @protected
      * @memberOf {Context}
      * @method
      *
      * @returns {Object}
      * */
-    toJSON: function () {
+    _dumpArgs: function () {
 
-        return {
-            errors: this.errors,
-            result: this.result
-        };
+        return _.extend({}, this.track.url.query,
+            this.track.match, this.__base());
     }
 
 });

--- a/core/deps/deps.js
+++ b/core/deps/deps.js
@@ -94,18 +94,19 @@ var Deps = inherit(/** @lends Deps.prototype */ {
      * @memberOf {Deps}
      * @method
      *
-     * @param {String} name
+     * @param {String} path
+     * @param {*} [defaultValue]
      *
      * @returns {*}
      * */
-    arg: function (name) {
+    arg: function (path, defaultValue) {
+        var result = ns.use(this.args(), path);
 
-        if ( _.has(this.params, name) ) {
-
-            return this.params[name];
+        if ( this._isFalsy(result) ) {
+            result = defaultValue;
         }
 
-        return void 0;
+        return result;
     },
 
     /**
@@ -113,13 +114,15 @@ var Deps = inherit(/** @lends Deps.prototype */ {
      * @memberOf {Deps}
      * @method
      *
-     * @param {String} path
-     *
      * @returns {*}
      * */
-    getRes: function (path) {
+    args: function () {
 
-        return ns.use(this.result, path);
+        if ( !this.__args ) {
+            this.__args  = this._dumpArgs();
+        }
+
+        return this.__args;
     },
 
     /**
@@ -127,13 +130,29 @@ var Deps = inherit(/** @lends Deps.prototype */ {
      * @memberOf {Deps}
      * @method
      *
-     * @param {String} path
+     * @param {String} [path]
+     * @param {*} [defaultValue]
      *
      * @returns {*}
      * */
-    getErr: function (path) {
+    getRes: function (path, defaultValue) {
+        /*eslint no-unused-vars: 0*/
+        return this.__get(this.result, arguments);
+    },
 
-        return ns.use(this.errors, path);
+    /**
+     * @public
+     * @memberOf {Deps}
+     * @method
+     *
+     * @param {String} [path]
+     * @param {*} [defaultValue]
+     *
+     * @returns {*}
+     * */
+    getErr: function (path, defaultValue) {
+        /*eslint no-unused-vars: 0*/
+        return this.__get(this.errors, arguments);
     },
 
     /**
@@ -225,6 +244,75 @@ var Deps = inherit(/** @lends Deps.prototype */ {
     setErr: function (path, data) {
 
         return ns.add(this.errors, path, data);
+    },
+
+    /**
+     * @public
+     * @memberOf {Deps}
+     * @method
+     *
+     * @returns {Object}
+     * */
+    toJSON: function () {
+
+        return {
+            params: this.args(),
+            errors: this.getErr(),
+            result: this.getRes()
+        };
+    },
+
+    /**
+     * @protected
+     * @memberOf {Deps}
+     * @method
+     *
+     * @returns {Object}
+     * */
+    _dumpArgs: function () {
+
+        return Object(this.params);
+    },
+
+    /**
+     * @protected
+     * @memberOf {Deps}
+     * @method
+     *
+     * @param {*} v
+     *
+     * @returns {Boolean}
+     * */
+    _isFalsy: function (v) {
+
+        return _.isUndefined(v) || _.isNull(v) || '' === v;
+    },
+
+    /**
+     * @private
+     * @memberOf {Deps}
+     * @method
+     *
+     * @param {*} root
+     * @param {Arguments} args
+     *
+     * @returns {*}
+     * */
+    __get: function (root, args) {
+        var result;
+
+        if ( 0 === args.length ) {
+
+            return root;
+        }
+
+        result = ns.use(root, args[0]);
+
+        if ( this._isFalsy(result) ) {
+            result = args[1];
+        }
+
+        return result;
     },
 
     /**

--- a/test/core.deps.context.js
+++ b/test/core.deps.context.js
@@ -7,6 +7,31 @@ describe('core/deps/context', function () {
     /*eslint max-nested-callbacks: [2, 5]*/
     var Context = require('../core/deps/context');
 
+    describe('.args', function () {
+        it('Should correctly dump args', function () {
+            var ctx = new Context({
+                match: {
+                    a: 42
+                },
+                url: {
+                    query: {
+                        a: 43
+                    }
+                }
+            }, null, {
+                a: 41
+            });
+
+            var args = ctx.args();
+
+            assert.deepEqual(args, {
+                a: 41
+            });
+
+            assert.strictEqual(args, ctx.args());
+        });
+    });
+
     describe('.arg', function () {
         it('Should return instance parameter', function () {
 
@@ -61,15 +86,31 @@ describe('core/deps/context', function () {
 
             assert.strictEqual(ctx.arg('a'), 43);
         });
-    });
 
-    describe('.toJSON', function () {
-        it('Should serialize to JSON', function () {
-            var context = new Context();
-            assert.deepEqual(context.toJSON(), {
-                result: {},
-                errors: {}
+        it('Should support paths', function () {
+
+            var ctx = new Context({
+                match: {},
+                url: {
+                    query: {
+                        sort: {
+                            type: 'asc'
+                        }
+                    }
+                }
             });
+
+            assert.strictEqual(ctx.arg('sort.type'), 'asc');
+        });
+
+        it('Should support defaultValues', function () {
+
+            var ctx = new Context({
+                match: {},
+                url: {query: {}}
+            });
+
+            assert.strictEqual(ctx.arg('sort.type', 'asc'), 'asc');
         });
     });
 

--- a/test/core.deps.deps.js
+++ b/test/core.deps.deps.js
@@ -66,21 +66,61 @@ describe('core/deps/deps', function () {
         });
     });
 
-    describe('.getRes(path)', function () {
+    describe('.getRes', function () {
         it('Should get data from .res object', function () {
             var ctx = new Deps(track);
 
             ctx.setRes('a.b.c', 42);
             assert.strictEqual(ctx.getRes('a.b.c'), 42);
         });
+
+        it('Should support default value', function () {
+            var ctx = new Deps(track);
+
+            assert.strictEqual(ctx.getRes('a.b.c', 42), 42);
+        });
+
+        it('Should support no arguments', function () {
+            var ctx = new Deps(track);
+
+            ctx.setRes('a.b.c', 42);
+
+            assert.deepEqual(ctx.getRes(), {
+                a: {
+                    b: {
+                        c: 42
+                    }
+                }
+            });
+        });
     });
 
-    describe('.getErr(path)', function () {
+    describe('.getErr', function () {
         it('Should get data from .ers object', function () {
             var ctx = new Deps(track);
 
             ctx.setErr('a.b.c', 42);
             assert.strictEqual(ctx.getErr('a.b.c'), 42);
+        });
+
+        it('Should support default value', function () {
+            var ctx = new Deps(track);
+
+            assert.strictEqual(ctx.getErr('a.b.c', 42), 42);
+        });
+
+        it('Should support no arguments', function () {
+            var ctx = new Deps(track);
+
+            ctx.setErr('a.b.c', 42);
+
+            assert.deepEqual(ctx.getErr(), {
+                a: {
+                    b: {
+                        c: 42
+                    }
+                }
+            });
         });
     });
 
@@ -125,6 +165,22 @@ describe('core/deps/deps', function () {
         });
     });
 
+    describe('.args', function () {
+
+        it('Should return args', function () {
+            var ctx = new Deps(track, 'c', {
+                a: 42
+            });
+            var args = ctx.args();
+
+            assert.deepEqual(args, {
+                a: 42
+            });
+
+            assert.strictEqual(args, ctx.args());
+        });
+    });
+
     describe('.arg', function () {
         it('Should return parameter', function () {
             var ctx = new Deps(track, 'c', {
@@ -132,6 +188,40 @@ describe('core/deps/deps', function () {
             });
 
             assert.strictEqual(ctx.arg('a'), 42);
+        });
+
+        it('Should support paths', function () {
+            var ctx = new Deps(track, 'c', {
+                a: {
+                    b: 42
+                }
+            });
+
+            assert.strictEqual(ctx.arg('a.b'), 42);
+        });
+
+        it('Should not fail if no params', function () {
+            var ctx = new Deps(track, 'c');
+
+            assert.strictEqual(ctx.arg('a.b'), void 0);
+        });
+
+        it('Should support default value', function () {
+            var ctx = new Deps(track, 'c');
+            var def = {};
+
+            assert.strictEqual(ctx.arg('a.b', def), def);
+        });
+    });
+
+    describe('.toJSON', function () {
+        it('Should serialize to JSON', function () {
+            var context = new Deps();
+            assert.deepEqual(context.toJSON(), {
+                params: {},
+                result: {},
+                errors: {}
+            });
         });
     });
 });


### PR DESCRIPTION
1. context.arg('path.to.prop')
2. context.arg('name', defaultValue);
3. context.getRes('path.to.result', defaultValue);
4. context.getRes();
5. context.args()
6. Imporove context.toJSON() (add params property)

closes #186 
