### PR TITLE
[WIP] Improve logging layer

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -364,13 +364,13 @@ Core.prototype._callPlugin = function (func) {
 function createInstaller(moduleName) {
     return function (app) {
         if (_.has(app._installed, moduleName)) {
-            app.logger.debug('The plugin %s has already installed, skipping', moduleName);
+            app.logger.internal('The plugin %s has already installed, skipping', moduleName);
             return;
         }
 
         app._installed[moduleName] = true;
 
-        app.logger.debug('Installing plugin %s', moduleName);
+        app.logger.internal('Installing plugin %s', moduleName);
         app.plugin(require(moduleName));
     };
 }

--- a/core/core.js
+++ b/core/core.js
@@ -42,7 +42,7 @@ function Core(params) {
      * @property
      * @type {Logger}
      * */
-    this.logger = logging.getLogger(params.name).conf(params.logging);
+    this.logger = this.createLogger();
 
     /**
      * @protected
@@ -95,6 +95,17 @@ function Core(params) {
  * @constructs
  * */
 Core.prototype.constructor = Core;
+
+/**
+ * @public
+ * @memberOf {Core}
+ * @method
+ *
+ * @returns {Logger}
+ * */
+Core.prototype.createLogger = function () {
+    return logging.getLogger(this.params.name).conf(this.params.logging);
+};
 
 /**
  * @public

--- a/core/runtime.js
+++ b/core/runtime.js
@@ -232,7 +232,7 @@ Runtime.startRun = function $Runtime$startRun(unit, track, args, done) {
         runtime.context = new Context(runtime.context.params, logger);
 
         // is not it so extraneous?
-        logger.debug('Running...');
+        logger.internal('[%(identity)s] Running...', runtime);
 
         // Set runtime creation date
         runtime.creationDate = new Date();
@@ -431,7 +431,7 @@ function $Runtime$callUnitMain(runtime) {
 
 function $Runtime$onCacheGot(runtime, err, res) {
     if (res) {
-        runtime.context.logger.debug('Found in cache');
+        runtime.context.logger.internal('[%(identity)s] Found cache by "%(cacheKey)s"', runtime);
         runtime.value = res.value;
         // set `accepted` bit
         runtime.statusBits |= B00000001;
@@ -443,7 +443,7 @@ function $Runtime$onCacheGot(runtime, err, res) {
         runtime.context.logger.warn(err);
     } else {
         // value was not found in cache
-        runtime.context.logger.debug('Outdated');
+        runtime.context.logger.internal('[%(identity)s] Outdated by "%(cacheKey)s"', runtime);
     }
 
     // set `updating` bit, schedule update
@@ -464,13 +464,13 @@ function $Runtime$finish(runtime) {
 
     if (runtime.statusBits & B00000001) {
         //  has `accepted` bit
-        runtime.context.logger.debug('Accepted in %dms', timePassed);
+        runtime.context.logger.debug('[%(identity)s] Accepted in %dms', timePassed, runtime);
     } else if (runtime.statusBits & B00000010) {
         //  has `rejected` bit
-        runtime.context.logger.debug('Rejected in %dms', timePassed);
+        runtime.context.logger.debug('[%(identity)s] Rejected in %dms', timePassed, runtime);
     } else {
         // has no both `accepted` and `rejected` bits
-        runtime.context.logger.debug('Skipping in %dms', timePassed);
+        runtime.context.logger.debug('[%(identity)s] Skipping in %dms', timePassed, runtime);
     }
 
     // call runtime.done without context
@@ -508,11 +508,11 @@ function $Runtime$afterMainCalled2(runtime, value, statusBitMask) {
 }
 
 function $Runtime$onCacheSet(runtime, err) {
-    // Just noop function, cache set issues
+    // Just noop function, log cache set issues
     if (err) {
         runtime.context.logger.warn(err);
     } else {
-        runtime.context.logger.debug('Updated');
+        runtime.context.logger.internal('[%(identity)s] Updated by "%(cacheKey)s"', runtime);
     }
 }
 

--- a/core/server.js
+++ b/core/server.js
@@ -88,7 +88,13 @@ Server.prototype.getHandler = function () {
  * @returns {http.Server}
  * */
 Server.prototype.listen = function () {
+    var self = this;
     var server = http.createServer(this.getHandler());
+
+    server.once('listening', function () {
+        // WARNING: server._connectionKey looking private
+        self.logger.log('Listening %(_connectionKey)s', server);
+    });
 
     //  Asynchronous run initialization
     this.ready().done();

--- a/core/server.js
+++ b/core/server.js
@@ -62,9 +62,10 @@ Server.prototype.getHandler = function () {
 
         track = new Connect(this, this.logger.bind(req.id), req, res);
 
-        track.logger.info('Incoming %(method)s %(url)s %s', function () {
+        track.logger.info('Incoming %(method)s %(url)s', req);
+        track.logger.debug('Request headers: %s', function () {
             return _.reduce(req.headers, addHeaderString, '');
-        }, req);
+        });
 
         res.on('finish', function () {
             var code = res.statusCode;

--- a/core/unit.js
+++ b/core/unit.js
@@ -6,6 +6,7 @@ var LRUDictTtlAsync = require('lru-dict/core/lru-dict-ttl-async');
 var _ = require('lodash-node');
 var f = require('util').format;
 var inherit = require('inherit');
+var logging = require('loggin');
 
 /**
  * @class Unit
@@ -246,7 +247,8 @@ Unit.inherit = function (members, statics) {
  * @returns {Logger}
  * */
 Unit.prototype.createLogger = function () {
-    return this.app.logger.bind(this.name);
+    var config = _.extend({}, this.app.params.logging, this.settings.logging);
+    return logging.getLogger(this.name).conf(config);
 };
 
 /**

--- a/core/utils/core-tools.js
+++ b/core/utils/core-tools.js
@@ -44,7 +44,7 @@ function createUnitClass(app, decl) {
     //  Looking for base
     if (_.isUndefined(base)) {
         base = app.params.implicitBase;
-        app.logger.debug('The base for unit "%s" is implicitly defined as "%s"', name, base);
+        app.logger.internal('The base for unit "%s" is implicitly defined as "%s"', name, base);
     }
 
     if (base === app.Unit.prototype.name) {

--- a/test/core.unit.js
+++ b/test/core.unit.js
@@ -498,10 +498,8 @@ describe('core/unit', function () {
     describe('unit.createLogger()', function () {
         it('Should be a function', function () {
             var unit = getUnit({
-                logger: {
-                    bind: function () {
-                        return {};
-                    }
+                params: {
+                    logging: {}
                 }
             }, {
                 freezeDepsList: function () {},
@@ -512,14 +510,10 @@ describe('core/unit', function () {
             });
             assert.strictEqual(typeof unit.createLogger, 'function');
         });
-        it('Should return logger, bound to unit name', function () {
-            var logger = {};
+        it('Should return logger named as unit', function () {
             var unit = getUnit({
-                logger: {
-                    bind: function (name) {
-                        assert.strictEqual(name, 'foo');
-                        return logger;
-                    }
+                params: {
+                    logging: {}
                 }
             }, {
                 name: 'foo',
@@ -529,7 +523,45 @@ describe('core/unit', function () {
                 freezeDepsArgs: function () {},
                 freezeDepsIndex: function () {}
             });
-            assert.strictEqual(unit.logger, logger);
+            assert.strictEqual(unit.logger.context, 'foo');
+        });
+        it('Should extend app.params.logging with unit.settings.logging', function () {
+            var unit = getUnit({
+                params: {
+                    logging: {
+                        logLevel: 'DEBUG'
+                    }
+                }
+            }, {
+                name: 'foo',
+                settings: {},
+                freezeDepsList: function () {},
+                createCache: function () {},
+                freezeDepsMap: function () {},
+                freezeDepsArgs: function () {},
+                freezeDepsIndex: function () {}
+            });
+            var unit2 = getUnit({
+                params: {
+                    logging: {
+                        logLevel: 'DEBUG'
+                    }
+                }
+            }, {
+                name: 'bar',
+                settings: {
+                    logging: {
+                        logLevel: 'FATAL'
+                    }
+                },
+                freezeDepsList: function () {},
+                createCache: function () {},
+                freezeDepsMap: function () {},
+                freezeDepsArgs: function () {},
+                freezeDepsIndex: function () {}
+            });
+            assert.strictEqual(unit.logger.logLevel, 'DEBUG');
+            assert.strictEqual(unit2.logger.logLevel, 'FATAL');
         });
     });
     describe('unit.main()', function () {
@@ -576,8 +608,8 @@ describe('core/unit', function () {
         it('Should create subclass of Unit', function () {
             var Unit2 = Unit.inherit();
             var unit = new Unit2({
-                logger: {
-                    bind: function () {}
+                params: {
+                    logging: {}
                 }
             });
             assert.ok(unit instanceof Unit);

--- a/test/core.utils.core-tools.js
+++ b/test/core.utils.core-tools.js
@@ -33,7 +33,7 @@ describe('core/utils/core-tools', function () {
             var core = {
                 Unit: SpyUnit,
                 logger: {
-                    debug: function () {}
+                    internal: function () {}
                 },
                 params: {
                     implicitBase: 0
@@ -55,7 +55,7 @@ describe('core/utils/core-tools', function () {
             var core = {
                 Unit: SpyUnit,
                 logger: {
-                    debug: function () {}
+                    internal: function () {}
                 },
                 params: {
                     implicitBase: 0
@@ -92,7 +92,7 @@ describe('core/utils/core-tools', function () {
             var core = {
                 Unit: SpyUnit,
                 logger: {
-                    debug: function () {}
+                    internal: function () {}
                 },
                 params: {
                     implicitBase: 0
@@ -142,7 +142,7 @@ describe('core/utils/core-tools', function () {
             var core = {
                 Unit: SpyUnit,
                 logger: {
-                    debug: function () {}
+                    internal: function () {}
                 },
                 params: {
                     implicitBase: 0


### PR DESCRIPTION
1. Reduce log levels of some annoying messages, also increate theirs detaization
2. Kill feature: give units own loggers, now units, can have own logging settings.

```js
var app = fist({
    logLevel: 'LOG'
});

app.unit({
    name: 'foo',
    settings: {
        // easy to develop
        logging: {logLevel: 'DEBUG'}
    }
});
```
3. Log server._connectionKey on listening

TODO: Update docs